### PR TITLE
Do not allow duplicate related posts.

### DIFF
--- a/lib/jekyll-related-posts.rb
+++ b/lib/jekyll-related-posts.rb
@@ -75,6 +75,7 @@ module Jekyll
     def find_releated(count = 5, min_score = -10.0, accuracy = 1.0)
       dc = document_correleation(accuracy)
       result = Hash.new
+      result_ids = Hash.new
       count = [count, @posts.size].min
 
       @posts.each_with_index do |post, index|
@@ -83,15 +84,19 @@ module Jekyll
         end
 
         result[post] = []
+        result_ids[post] = Set.new
         count.times do
           score, id = queue.pop
           break unless score
           begin
-            result[post] << {
-              'score' => score,
-              'url' => @posts[id][:url],
-              'title' => @posts[id][:title]
-            }
+            unless result_ids[post].include? id
+              result_ids[post].add(id)
+              result[post] << {
+                'score' => score,
+                'url' => @posts[id][:url],
+                'title' => @posts[id][:title]
+              }
+            end
           rescue
             break
           end


### PR DESCRIPTION
When the Jekyll install has a low number of posts, it's likely that we will show duplicate related posts. This PR makes sure that doesn't happen.